### PR TITLE
add ffmpeg-full as extension to fix laggy video playback

### DIFF
--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -16,7 +16,9 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    version: "24.08"
+    versions: 
+      - 23.08
+      - 24.08
     no-autodownload: false
     autodelete: false
 cleanup-commands:

--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -12,6 +12,15 @@ finish-args:
     - --device=dri
     - --socket=pulseaudio
     - --talk-name=org.kde.StatusNotifierWatcher
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    add-ld-path: .
+    version: "24.08"
+    no-autodownload: false
+    autodelete: false
+cleanup-commands:
+    - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 modules:
     ########################
     # EXIV2

--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -16,9 +16,7 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    versions: 
-      - 23.08
-      - 24.08
+    versions: '24.08;23.08'
     no-autodownload: false
     autodelete: false
 cleanup-commands:


### PR DESCRIPTION
Video playback tends to be very choppy with the Flatpak. This adds ffmpeg-full as extension which fixes that and results in smooth video playback (if installed).