### PR TITLE
fix commit hash for v4.8.1

### DIFF
--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -413,5 +413,5 @@ modules:
       sources:
         - type: git
           url: https://gitlab.com/lspies/photoqt.git
-          commit: c4951f5aa9af6475a2a5fd3544aa9b1c49118988
+          commit: 9e1b6ba1f0a82565e0111c79b579e0f924ea33fe
           tag: v4.8.1


### PR DESCRIPTION
Wrong commit hash was specified for latest release of PhotoQt.