### PR TITLE
Revert "Reduce package size"

### DIFF
--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -16,21 +16,11 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    version: '24.08'
+    versions: '23.08;24.08'
     no-autodownload: false
     autodelete: false
 cleanup-commands:
     - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
-cleanup:
-  - /include
-  - /lib/pkgconfig
-  - /lib/cmake
-  - /share/pkgconfig
-  - /share/boost_predef
-  - /share/doc
-  - /share/man
-  - '*.a'
-  - '*.la'
 modules:
     ########################
     # EXIV2
@@ -50,8 +40,8 @@ modules:
       sources:
         - type: git
           url: https://github.com/Exiv2/exiv2
-          commit: 907169fa643c2c74c14fd4106e55eaeee3634d9f
-          tag: v0.28.5
+          commit: a6a79ef064f131ffd03c110acce2d3edb84ffa2e
+          tag: v0.28.3
 
     ########################
     # RAW SUPPORT
@@ -68,6 +58,73 @@ modules:
         - type: shell
           commands:
             - "autoreconf -vfi"
+
+    ########################
+    # HEIF SUPPORT
+    ########################
+    - name: libde265
+      buildsystem: cmake-ninja
+      config-opts:
+        - -DCMAKE_BUILD_TYPE=Release
+      sources:
+        - type: git
+          url: https://github.com/strukturag/libde265
+          commit: 17bb8d9fcea62db8cdeb0fc7ef8d15dbd19a22e4
+          tag: v1.0.15
+    ########################
+    - name: libheif
+      buildsystem: cmake-ninja
+      config-opts:
+        - -DCMAKE_BUILD_TYPE=Release
+        - -DWITH_DAV1D=ON
+        - -DWITH_RAV1E=ON
+        - -DBUILD_TESTING=OFF
+        - -DWITH_EXAMPLES=OFF
+        - -DENABLE_PLUGIN_LOADING=OFF
+        - -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
+      sources:
+        - type: git
+          url: https://github.com/strukturag/libheif
+          commit: cd95b113d78d0696105a9e678cbd19487ee13d6c
+          tag: v1.19.5
+
+    ########################
+    # AVIF SUPPORT
+    ########################
+    - name: libyuf
+      buildsystem: cmake-ninja
+      config-opts:
+        - -DCMAKE_BUILD_TYPE=Release
+      sources:
+        - type: git
+          url: https://chromium.googlesource.com/libyuv/libyuv/
+          commit: 26277baf96fd95bf6efa4abab82775bde9bc5ccb
+    - name: libavif
+      buildsystem: cmake-ninja
+      config-opts:
+        - -DCMAKE_BUILD_TYPE=Release
+        - -DAVIF_CODEC_AOM=ON
+        - -DAVIF_CODEC_DAV1D=ON
+        - -DAVIF_CODEC_AOM=ON
+      sources:
+        - type: git
+          url: https://github.com/AOMediaCodec/libavif
+          commit: bb24db03cd99befe09c87b602e36f24d75a980d1
+          tag: v1.1.1
+
+    ########################
+    # JXL SUPPORT
+    ########################
+    - name: libjxl
+      buildsystem: cmake-ninja
+      config-opts:
+        - -DCMAKE_BUILD_TYPE=Release
+        - -DBUILD_TESTING=OFF
+      sources:
+        - type: git
+          url: https://github.com/libjxl/libjxl
+          commit: 794a5dcf0d54f9f0b20d288a12e87afb91d20dfc
+          tag: v0.11.1
 
     ########################
     # EXR SUPPORT
@@ -118,11 +175,9 @@ modules:
     ########################
     - name: boost
       buildsystem: simple
-      cleanup:
-        - "libboost*.so*"
       build-commands:
-        - ./bootstrap.sh --with-libraries=container
-        - ./b2 install variant=release link=shared runtime-link=shared --prefix="$FLATPAK_DEST" -j $FLATPAK_BUILDER_N_JOBS
+        - ./bootstrap.sh
+        - ./b2 install --prefix="$FLATPAK_DEST"
       sources:
         - type: archive
           url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
@@ -287,6 +342,7 @@ modules:
     ########################
     - name: imagemagick
       builddir: true
+      build-options:
       config-opts:
         - --enable-shared
         - --disable-static
@@ -338,21 +394,21 @@ modules:
       builddir: true
       config-opts:
         - -DCMAKE_BUILD_TYPE=Release
-        - -DWITH_IMAGEMAGICK=ON
-        - -DWITH_GRAPHICSMAGICK=OFF
-        - -DWITH_EXIV2=ON
-        - -DWITH_LIBARCHIVE=ON
+        - -DIMAGEMAGICK=ON
+        - -DGRAPHICSMAGICK=OFF
+        - -DEXIV2=ON
+        - -DLIBARCHIVE=ON
         - -DRAW=ON
-        - -DWITH_POPPLER=ON
-        - -DWITH_QTPDF=OFF
-        - -DWITH_DEVIL=ON
-        - -DWITH_FREEIMAGE=OFF
-        - -DWITH_PUGIXML=ON
-        - -DWITH_CHROMECAST=OFF
-        - -DWITH_LIBVIPS=OFF
-        - -DWITH_VIDEO_MPV=ON
+        - -DPOPPLER=ON
+        - -DQTPDF=OFF
+        - -DDEVIL=ON
+        - -DFREEIMAGE=OFF
+        - -DPUGIXML=ON
+        - -DCHROMECAST=OFF
+        - -DLIBVIPS=OFF
+        - -DVIDEO_MPV=ON
         - -DEXIV2_ENABLE_BMFF=ON
-        - -DWITH_ZXING=ON
+        - -DZXING=ON
         - -DFLATPAKBUILD=ON
       sources:
         - type: git


### PR DESCRIPTION
Reverts flathub/org.photoqt.PhotoQt#42

This pull request causes PhotoQt to loose ~ 1/3 of supported file types. A more careful investigation needs to be done to see which parts need to be re-added.