### PR TITLE
remove duplicate packages, add cleanup steps, changes adapted from #42

### DIFF
--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -16,11 +16,20 @@ add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
     add-ld-path: .
-    versions: '23.08;24.08'
+    version: '24.08'
     no-autodownload: false
     autodelete: false
 cleanup-commands:
     - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+cleanup:
+    - /include
+    - /lib/pkgconfig
+    - /lib/cmake
+    - /share/pkgconfig
+    - /share/boost_predef
+    - /share/doc
+    - /share/man
+    - '*.a'
 modules:
     ########################
     # EXIV2
@@ -40,8 +49,8 @@ modules:
       sources:
         - type: git
           url: https://github.com/Exiv2/exiv2
-          commit: a6a79ef064f131ffd03c110acce2d3edb84ffa2e
-          tag: v0.28.3
+          commit: 907169fa643c2c74c14fd4106e55eaeee3634d9f
+          tag: v0.28.5
 
     ########################
     # RAW SUPPORT
@@ -58,73 +67,6 @@ modules:
         - type: shell
           commands:
             - "autoreconf -vfi"
-
-    ########################
-    # HEIF SUPPORT
-    ########################
-    - name: libde265
-      buildsystem: cmake-ninja
-      config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-      sources:
-        - type: git
-          url: https://github.com/strukturag/libde265
-          commit: 17bb8d9fcea62db8cdeb0fc7ef8d15dbd19a22e4
-          tag: v1.0.15
-    ########################
-    - name: libheif
-      buildsystem: cmake-ninja
-      config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DWITH_DAV1D=ON
-        - -DWITH_RAV1E=ON
-        - -DBUILD_TESTING=OFF
-        - -DWITH_EXAMPLES=OFF
-        - -DENABLE_PLUGIN_LOADING=OFF
-        - -DCMAKE_COMPILE_WARNING_AS_ERROR=OFF
-      sources:
-        - type: git
-          url: https://github.com/strukturag/libheif
-          commit: cd95b113d78d0696105a9e678cbd19487ee13d6c
-          tag: v1.19.5
-
-    ########################
-    # AVIF SUPPORT
-    ########################
-    - name: libyuf
-      buildsystem: cmake-ninja
-      config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-      sources:
-        - type: git
-          url: https://chromium.googlesource.com/libyuv/libyuv/
-          commit: 26277baf96fd95bf6efa4abab82775bde9bc5ccb
-    - name: libavif
-      buildsystem: cmake-ninja
-      config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DAVIF_CODEC_AOM=ON
-        - -DAVIF_CODEC_DAV1D=ON
-        - -DAVIF_CODEC_AOM=ON
-      sources:
-        - type: git
-          url: https://github.com/AOMediaCodec/libavif
-          commit: bb24db03cd99befe09c87b602e36f24d75a980d1
-          tag: v1.1.1
-
-    ########################
-    # JXL SUPPORT
-    ########################
-    - name: libjxl
-      buildsystem: cmake-ninja
-      config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DBUILD_TESTING=OFF
-      sources:
-        - type: git
-          url: https://github.com/libjxl/libjxl
-          commit: 794a5dcf0d54f9f0b20d288a12e87afb91d20dfc
-          tag: v0.11.1
 
     ########################
     # EXR SUPPORT
@@ -175,9 +117,11 @@ modules:
     ########################
     - name: boost
       buildsystem: simple
+      cleanup:
+        - "libboost*.so*"
       build-commands:
-        - ./bootstrap.sh
-        - ./b2 install --prefix="$FLATPAK_DEST"
+        - ./bootstrap.sh --with-libraries=container
+        - ./b2 install variant=release link=shared runtime-link=shared --prefix="$FLATPAK_DEST" -j $FLATPAK_BUILDER_N_JOBS
       sources:
         - type: archive
           url: https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.gz
@@ -342,7 +286,6 @@ modules:
     ########################
     - name: imagemagick
       builddir: true
-      build-options:
       config-opts:
         - --enable-shared
         - --disable-static
@@ -393,23 +336,22 @@ modules:
       buildsystem: cmake-ninja
       builddir: true
       config-opts:
-        - -DCMAKE_BUILD_TYPE=Release
-        - -DIMAGEMAGICK=ON
-        - -DGRAPHICSMAGICK=OFF
-        - -DEXIV2=ON
-        - -DLIBARCHIVE=ON
-        - -DRAW=ON
-        - -DPOPPLER=ON
-        - -DQTPDF=OFF
-        - -DDEVIL=ON
-        - -DFREEIMAGE=OFF
-        - -DPUGIXML=ON
-        - -DCHROMECAST=OFF
-        - -DLIBVIPS=OFF
-        - -DVIDEO_MPV=ON
-        - -DEXIV2_ENABLE_BMFF=ON
-        - -DZXING=ON
-        - -DFLATPAKBUILD=ON
+        - -DWITH_IMAGEMAGICK=ON
+        - -DWITH_GRAPHICSMAGICK=OFF
+        - -DWITH_EXIV2=ON
+        - -DWITH_LIBARCHIVE=ON
+        - -DWITH_LIBRAW=ON
+        - -DWITH_POPPLER=ON
+        - -DWITH_QTPDF=OFF
+        - -DWITH_DEVIL=ON
+        - -DWITH_FREEIMAGE=OFF
+        - -DWITH_PUGIXML=ON
+        - -DWITH_CHROMECAST=OFF
+        - -DWITH_LIBVIPS=OFF
+        - -DWITH_VIDEO_MPV=ON
+        - -DWITH_EXIV2_ENABLE_BMFF=ON
+        - -DWITH_ZXING=ON
+        - -DWITH_FLATPAKBUILD=ON
       sources:
         - type: git
           url: https://gitlab.com/lspies/photoqt.git


### PR DESCRIPTION
Same changes as with #42:
- remove libjxl (used from runtime)
- remove libavif (use runtime)
- remove libheic (use runtime)
- only build boost headers
- cleanup rules
- don't use deprecate config option for photoqt
- update exiv2 to latest
- ffmpeg version should match runtime

Changes from #42 :
- modified cleanup rules
- modified config options for photoqt