### PR TITLE
Disable shared library verification

### DIFF
--- a/org.photoqt.PhotoQt.yml
+++ b/org.photoqt.PhotoQt.yml
@@ -354,6 +354,7 @@ modules:
         - -DWITH_EXTENSIONS_SUPPORT=ON
         - -DWITH_LIBSAI=OFF
         - -DWITH_FFMPEGTHUMBNAILER=ON
+        - -DWITH_EXTENSIONS_LIBRARY_VERIFICATION=OFF
       sources:
         - type: git
           url: https://gitlab.com/lspies/photoqt.git


### PR DESCRIPTION
The shared libraries of the extensions cannot be signed, only the qml/txt files can be.